### PR TITLE
Turn off caching in views with refresh bugs

### DIFF
--- a/client/www/js/app.js
+++ b/client/www/js/app.js
@@ -34,6 +34,7 @@ angular.module('phavr', ['ionic', 'ngCordova', 'phavr.login', 'phavr.home', 'pha
   })
 
   $stateProvider.state('favormap', {
+    cache: false,
     url: '/favormap',
     templateUrl: './views/favorMap.html',
     controller: 'FavorMapCtrl'
@@ -46,18 +47,21 @@ angular.module('phavr', ['ionic', 'ngCordova', 'phavr.login', 'phavr.home', 'pha
   })
 
   $stateProvider.state('favor', {
+    cache: false,
     url: '/favor',
     templateUrl: './views/favor.html',
     controller: 'favorCtrl'
   })
 
   $stateProvider.state('favordetails', {
+    cache: false,
     url: '/favordetails',
     templateUrl: './views/favorDetails.html',
     controller: 'favorDetailsCtrl'
   })
 
   $stateProvider.state('profile', {
+    cache: false,
     url: '/profile',
     templateUrl: 'views/profile.html',
     controller: 'profileCtrl'


### PR DESCRIPTION
I think that turning off caching will fix many bugs:
  wrong favor in favor details
  refresh of map view
  persistence of old data in favor creation view
